### PR TITLE
Fix capitalize function for strings with extra spaces

### DIFF
--- a/src/__tests__/string-manipulation.helper.test.ts
+++ b/src/__tests__/string-manipulation.helper.test.ts
@@ -1,0 +1,15 @@
+import { capitalize } from '../utils/string-manipulation.helper';
+
+describe('capitalize', () => {
+  it('capitalizes each word', () => {
+    expect(capitalize('hello world')).toBe('Hello World');
+  });
+
+  it('handles multiple spaces and trimming', () => {
+    expect(capitalize('  hello   world  ')).toBe('Hello World');
+  });
+
+  it('handles empty string', () => {
+    expect(capitalize('')).toBe('');
+  });
+});

--- a/src/utils/string-manipulation.helper.ts
+++ b/src/utils/string-manipulation.helper.ts
@@ -2,6 +2,7 @@
 export function capitalize(str: string) {
   return str
     .split(' ')
+    .filter((word) => word.length > 0)
     .map((word) => word[0].toUpperCase() + word.slice(1))
     .join(' ');
 }


### PR DESCRIPTION
## Summary
- improve `capitalize` utility to ignore empty words
- add unit tests for `capitalize`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68432efadf9c832fb6ba290caad3807b