### PR TITLE
Add tests

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,0 +1,16 @@
+import { getClient, LEETCODE_GRAPHQL_API_URL } from '../lib/client';
+import { GraphQLClient } from 'graphql-request';
+
+describe('getClient', () => {
+  it('returns a GraphQLClient instance with the correct url', () => {
+    const client = getClient();
+    expect(client).toBeInstanceOf(GraphQLClient);
+    expect((client as any).url).toBe(LEETCODE_GRAPHQL_API_URL);
+  });
+
+  it('returns the same instance on subsequent calls', () => {
+    const first = getClient();
+    const second = getClient();
+    expect(first).toBe(second);
+  });
+});

--- a/src/__tests__/github-handler.test.ts
+++ b/src/__tests__/github-handler.test.ts
@@ -1,0 +1,57 @@
+import GithubHandler from '../handlers/GithubHandler';
+
+jest.mock('../constants', () => ({
+  GITHUB_CLIENT_ID: '',
+  GITHUB_CLIENT_SECRET: '',
+  GITHUB_REDIRECT_URI: '',
+}));
+
+describe('GithubHandler utility methods', () => {
+  beforeEach(() => {
+    (global as any).chrome = {
+      storage: {
+        sync: {
+          get: jest.fn((keys: any, cb: any) => cb({})),
+          clear: jest.fn(),
+        },
+      },
+    };
+  });
+
+  it('returns correct file extension for a language', () => {
+    const handler = new GithubHandler();
+    expect(handler.getProblemExtension('Python')).toBe('.py');
+    expect(handler.getProblemExtension('JavaScript')).toBe('.js');
+  });
+
+  it('returns correct difficulty color', () => {
+    const handler = new GithubHandler();
+    expect(handler.getDifficultyColor('Easy')).toBe('brightgreen');
+    expect(handler.getDifficultyColor('Medium')).toBe('orange');
+    expect(handler.getDifficultyColor('Hard')).toBe('red');
+  });
+
+  it('creates a difficulty badge using the difficulty color', () => {
+    const handler = new GithubHandler();
+    const badge = handler.createDifficultyBadge('Medium');
+    expect(badge).toContain('img');
+    expect(badge).toContain('Difficulty-Medium-orange');
+  });
+
+  it('loads token from storage', async () => {
+    const handler = new GithubHandler();
+    (global as any).chrome.storage.sync.get = jest.fn((keys: any, cb: any) => cb({ github_leetsync_token: 'abc' }));
+    const token = await handler.loadTokenFromStorage();
+    expect(token).toBe('abc');
+  });
+
+  it('returns empty string and clears storage when token missing', async () => {
+    const clear = jest.fn();
+    (global as any).chrome.storage.sync.get = jest.fn((keys: any, cb: any) => cb({}));
+    (global as any).chrome.storage.sync.clear = clear;
+    const handler = new GithubHandler();
+    const token = await handler.loadTokenFromStorage();
+    expect(token).toBe('');
+    expect(clear).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/leetcode-handler.test.ts
+++ b/src/__tests__/leetcode-handler.test.ts
@@ -1,0 +1,44 @@
+import LeetCodeHandler from '../handlers/LeetCodeHandler';
+import * as submissionApi from '../api/submissions/getSubmission';
+
+jest.mock('../api/submissions/getSubmission');
+
+describe('LeetCodeHandler getSubmission', () => {
+  beforeEach(() => {
+    (global as any).chrome = {
+      storage: { sync: { get: jest.fn() } }
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when there is no session token', async () => {
+    (global as any).chrome.storage.sync.get.mockResolvedValue({});
+    const handler = new LeetCodeHandler();
+    const result = await handler.getSubmission('two-sum');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no submissions exist', async () => {
+    (global as any).chrome.storage.sync.get.mockResolvedValue({ leetcode_session: 'sess' });
+    (submissionApi.getAllSubmission as jest.Mock).mockResolvedValue({});
+    const handler = new LeetCodeHandler();
+    const result = await handler.getSubmission('two-sum');
+    expect(result).toBeNull();
+  });
+
+  it('returns latest submission details', async () => {
+    (global as any).chrome.storage.sync.get.mockResolvedValue({ leetcode_session: 'sess' });
+    (submissionApi.getAllSubmission as jest.Mock).mockResolvedValue({
+      questionSubmissionList: { submissions: [{ id: 1 }] }
+    });
+    const details = { id: 1, code: 'code' } as any;
+    (submissionApi.getSubmission as jest.Mock).mockResolvedValue({ submissionDetails: details });
+
+    const handler = new LeetCodeHandler();
+    const result = await handler.getSubmission('two-sum');
+    expect(result).toEqual(details);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for GraphQL client
- cover GithubHandler helper methods
- test LeetCodeHandler submission fetching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843372a9dc8832f88a890eea5d19fb6